### PR TITLE
Include <SPIFFS.h> for ESP32

### DIFF
--- a/src/ESPFlash.h
+++ b/src/ESPFlash.h
@@ -24,6 +24,10 @@
 
 #include <FS.h>
 
+#if defined(ARDUINO_ARCH_ESP32)
+#include <SPIFFS.h>
+#endif
+
 template<class T>
 class ESPFlash
 {  


### PR DESCRIPTION
Include <SPIFFS.h> for ESP32 Boards. Fixes #6 